### PR TITLE
Set operador_id on sim cards when linking lines

### DIFF
--- a/app/Imports/LineasImport.php
+++ b/app/Imports/LineasImport.php
@@ -132,6 +132,9 @@ class LineasImport implements ToModel, WithChunkReading, SkipsOnError, SkipsOnFa
             ]);
 
             $simCard->lineas_id = $linea->id;
+            if (! $simCard->operador_id) {
+                $simCard->operador_id = $this->operadorId;
+            }
             $simCard->save();
 
             $this->registrarCambio($simCard, null, $linea->id);
@@ -163,6 +166,9 @@ class LineasImport implements ToModel, WithChunkReading, SkipsOnError, SkipsOnFa
         }
 
         $simCard->lineas_id = $linea->id;
+        if (! $simCard->operador_id) {
+            $simCard->operador_id = $this->operadorId;
+        }
         $simCard->save();
 
         $this->registrarCambio($simCard, null, $linea->id);


### PR DESCRIPTION
When registering a SIM to a line (registrarLineaConSimCard), set simCard->operador_id to $this->operadorId if it is not already present. The change adds conditional assignments in two places before saving the SIM so existing operador_id values are preserved while missing ones inherit the import's operadorId, ensuring imported/linked SIMs have an associated operador.