### PR TITLE
Set vehicle sim_card_id from Lineas

### DIFF
--- a/app/Http/Controllers/Api/TrackingWebhookController.php
+++ b/app/Http/Controllers/Api/TrackingWebhookController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Models\Dispositivos;
+use App\Models\Lineas;
 use App\Models\Vehiculos;
 use App\Scopes\EmpresaScope;
 use Illuminate\Http\JsonResponse;
@@ -66,10 +67,23 @@ class TrackingWebhookController extends Controller
             $cambios[] = 'gpswox_active';
         }
 
-        // --- numero (SIM) ---
+        // --- numero (SIM) + sim_card_id ---
         if (!blank($simNumber) && $vehiculo->numero !== $simNumber) {
             $vehiculo->numero = $simNumber;
             $cambios[] = 'numero';
+        }
+
+        if (!blank($simNumber)) {
+            $linea = Lineas::withoutGlobalScope(EmpresaScope::class)
+                ->where('numero', $simNumber)
+                ->first();
+
+            $simCard = $linea?->sim_card;
+
+            if ($simCard && $vehiculo->sim_card_id !== $simCard->id) {
+                $vehiculo->sim_card_id = $simCard->id;
+                $cambios[] = 'sim_card_id';
+            }
         }
 
         // --- Timestamp de sincronización ---


### PR DESCRIPTION
Import Lineas and, when a SIM number is provided, look up the corresponding Lineas record (without the EmpresaScope) by numero and retrieve its sim_card. If a sim_card is found and differs from the vehicle's current sim_card_id, update vehiculo->sim_card_id and record the change. Retains existing numero update and updates gpswox_sincronizado_at. Uses the null-safe operator to handle missing relations.