### PR TITLE
Replace existing work order signature

### DIFF
--- a/app/Http/Controllers/Api/WorkOrderController.php
+++ b/app/Http/Controllers/Api/WorkOrderController.php
@@ -403,16 +403,14 @@ class WorkOrderController extends Controller
         }
 
         try {
-            // Verificar si ya existe una firma del mismo tipo
+            // Si ya existe una firma del mismo tipo, eliminarla y reemplazarla
             $existingSignature = WorkOrderSignature::where('work_order_id', $workOrder->id)
                 ->where('tipo', $request->tipo)
                 ->first();
 
             if ($existingSignature) {
-                return response()->json([
-                    'success' => false,
-                    'message' => 'Ya existe una firma de ' . $request->tipo . ' para esta orden'
-                ], 422);
+                Storage::disk('private')->delete($existingSignature->path);
+                $existingSignature->delete();
             }
 
             // Decodificar base64


### PR DESCRIPTION
When saving a signature, remove the previous signature file and database record instead of returning a 422 error. The change deletes the existing file from the private storage (Storage::disk('private')->delete(...)) and deletes the WorkOrderSignature model so the new signature can be saved, allowing signature replacement and cleaning up stored files.